### PR TITLE
Introduce `Schema` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ KVS libraries provide following common features.
     - provide `get`, `set`, `has`, `delete`, and `clear` API
 - Version migration API
     - Upgrade date via `version`
+- Tiny package
+    - Almost package size is 1kb(gzip)
 
 ## Packages
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "lerna run build",
     "clean": "lerna run clean",
     "test": "lerna run test",
+    "ci": "lerna run test --ignore '@kvs/localstorage'",
     "versionup": "lerna version --conventional-commits",
     "versionup:patch": "lerna version patch --conventional-commits",
     "versionup:minor": "lerna version minor --conventional-commits",

--- a/packages/common-test-case/src/common-test-case.ts
+++ b/packages/common-test-case/src/common-test-case.ts
@@ -5,21 +5,21 @@ export type KVSTestCaseOptions = {
     setTestDataList: { name: string; value: any; type?: "object" }[];
 };
 export type KVSTestCaseRef = {
-    current: KVS<any, any> | null;
-    updateRef(ref: KVS<any, any>): void;
+    current: KVS<any> | null;
+    updateRef(ref: KVS<any>): void;
 };
 // version always be defined
 export const createKVSTestCase = (
-    kvsStorageConstructor: (options: Partial<KVSOptions<any, any>> & { version: number }) => Promise<KVS<any, any>>,
+    kvsStorageConstructor: (options: Partial<KVSOptions<any>> & { version: number }) => Promise<KVS<any>>,
     options: KVSTestCaseOptions
 ) => {
     const ref: KVSTestCaseRef = {
         current: null,
-        updateRef(target: KVS<any, any>) {
+        updateRef(target: KVS<any>) {
             ref.current = target;
         }
     };
-    let kvs: KVS<any, any>;
+    let kvs: KVS<any>;
     return {
         ref,
         run: () => {

--- a/packages/env/src/browser.ts
+++ b/packages/env/src/browser.ts
@@ -1,9 +1,9 @@
-import { JsonValue, KvsStorage } from "@kvs/storage";
-import { kvsIndexedDB } from "@kvs/indexeddb";
-import { KvsEnvStorageOptions } from "./share";
+import { KvsStorage } from "@kvs/storage";
+import { kvsIndexedDB, KvsIndexedDBOptions } from "@kvs/indexeddb";
+import { KvsEnvStorageOptions, KvsEnvStorageSchema } from "./share";
 
-export const kvsEnvStorage = async <K extends string, V extends JsonValue>(
-    options: KvsEnvStorageOptions<K, V>
-): Promise<KvsStorage<K, V>> => {
+export const kvsEnvStorage = async <Schema extends KvsEnvStorageSchema>(
+    options: KvsEnvStorageOptions<Schema> & KvsIndexedDBOptions<Schema>
+): Promise<KvsStorage<Schema>> => {
     return kvsIndexedDB(options);
 };

--- a/packages/env/src/node.ts
+++ b/packages/env/src/node.ts
@@ -1,9 +1,9 @@
-import { JsonValue, KvsStorage } from "@kvs/storage";
-import { kvsLocalStorage } from "@kvs/node-localstorage";
+import { kvsLocalStorage, KvsLocalStorage, KvsLocalStorageOptions } from "@kvs/node-localstorage";
 import { KvsEnvStorageOptions } from "./share";
+import { KVSIndexedSchema } from "@kvs/indexeddb/lib";
 
-export const kvsEnvStorage = async <K extends string, V extends JsonValue>(
-    options: KvsEnvStorageOptions<K, V>
-): Promise<KvsStorage<K, V>> => {
+export const kvsEnvStorage = async <Schema extends KVSIndexedSchema>(
+    options: KvsEnvStorageOptions<Schema> & KvsLocalStorageOptions<Schema>
+): Promise<KvsLocalStorage<Schema>> => {
     return kvsLocalStorage(options);
 };

--- a/packages/env/src/share.ts
+++ b/packages/env/src/share.ts
@@ -1,8 +1,8 @@
 import { JsonValue } from "@kvs/storage";
-import { KVS } from "@kvs/types";
+import { KVS, KVSOptions } from "@kvs/types";
 
 export type KvsEnvStorageSchema = {
     [index: string]: JsonValue;
 };
 export type KvsEnvStorage<Schema extends KvsEnvStorageSchema> = KVS<Schema>;
-export type KvsEnvStorageOptions<Schema extends KvsEnvStorageSchema> = KvsEnvStorage<Schema>;
+export type KvsEnvStorageOptions<Schema extends KvsEnvStorageSchema> = KVSOptions<Schema>;

--- a/packages/env/src/share.ts
+++ b/packages/env/src/share.ts
@@ -1,6 +1,8 @@
-import { JsonValue, KVSStorageKey } from "@kvs/storage";
+import { JsonValue } from "@kvs/storage";
 import { KVS } from "@kvs/types";
-import { KvsLocalStorageOptions } from "@kvs/node-localstorage";
 
-export type KvsEnvStorage<K extends KVSStorageKey, V extends JsonValue> = KVS<K, V>;
-export type KvsEnvStorageOptions<K extends KVSStorageKey, V extends JsonValue> = KvsLocalStorageOptions<K, V>;
+export type KvsEnvStorageSchema = {
+    [index: string]: JsonValue;
+};
+export type KvsEnvStorage<Schema extends KvsEnvStorageSchema> = KVS<Schema>;
+export type KvsEnvStorageOptions<Schema extends KvsEnvStorageSchema> = KvsEnvStorage<Schema>;

--- a/packages/indexeddb/README.md
+++ b/packages/indexeddb/README.md
@@ -10,7 +10,29 @@ Install with [npm](https://www.npmjs.com/):
 
 ## Usage
 
-- [ ] Write usage instructions
+```ts
+import { KVSIndexedDB, kvsIndexedDB } from "@kvs/indexeddb";
+(async () => {
+    type StorageSchema = {
+        a1: string;
+        b2: number;
+        c3: boolean;
+    };
+    const storage = await kvsIndexedDB<StorageSchema>({
+        name: "test",
+        version: 1,
+    });
+    await storage.set("a1", "string");
+    await storage.set("b2", 42);
+    await storage.set("c3", false);
+    const a1 = await storage.get("a1");
+    const b2 = await storage.get("b2");
+    const c3 = await storage.get("c3");
+    assert.strictEqual(a1, "string");
+    assert.strictEqual(b2, 42);
+    assert.strictEqual(c3, false);
+})();
+```
 
 ## Changelog
 

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -1,4 +1,5 @@
 import type { KVS, KVSOptions, StoreNames, StoreValue } from "@kvs/types";
+import { JsonValue } from "@kvs/storage";
 
 const debug = {
     enabled: false,
@@ -285,7 +286,7 @@ const createStore = <Schema extends KVSIndexedSchema>({
 };
 
 export type KVSIndexedSchema = {
-    [index: string]: any;
+    [index: string]: JsonValue;
 };
 export type KVSIndexedDB<Schema extends KVSIndexedSchema> = KVS<Schema> & IndexedDBResults;
 export type KvsIndexedDBOptions<Schema extends KVSIndexedSchema> = KVSOptions<Schema> & IndexedDBOptions;

--- a/packages/indexeddb/test/index.test.ts
+++ b/packages/indexeddb/test/index.test.ts
@@ -1,5 +1,6 @@
 import { KVSIndexedDB, kvsIndexedDB } from "../src";
 import { createKVSTestCase } from "@kvs/common-test-case";
+import assert from "assert";
 
 const databaseName = "kvs-test";
 const kvsTestCase = createKVSTestCase(
@@ -46,7 +47,7 @@ const kvsTestCase = createKVSTestCase(
     }
 );
 const deleteAllDB = async () => {
-    const kvs = kvsTestCase.ref.current as KVSIndexedDB<any, any> | null;
+    const kvs = kvsTestCase.ref.current as KVSIndexedDB<any> | null;
     if (!kvs) {
         return;
     }
@@ -62,4 +63,24 @@ describe("@kvs/indexedDB", () => {
     before(deleteAllDB);
     afterEach(deleteAllDB);
     kvsTestCase.run();
+    it("example", async () => {
+        type StorageSchema = {
+            a1: string;
+            b2: number;
+            c3: boolean;
+        };
+        const storage = await kvsIndexedDB<StorageSchema>({
+            name: databaseName,
+            version: 1
+        });
+        await storage.set("a1", "string");
+        await storage.set("b2", 42);
+        await storage.set("c3", false);
+        const a1 = await storage.get("a1");
+        const b2 = await storage.get("b2");
+        const c3 = await storage.get("c3");
+        assert.strictEqual(a1, "string");
+        assert.strictEqual(b2, 42);
+        assert.strictEqual(c3, false);
+    });
 });

--- a/packages/localstorage/README.md
+++ b/packages/localstorage/README.md
@@ -10,8 +10,30 @@ Install with [npm](https://www.npmjs.com/):
 
 ## Usage
 
-- [ ] Write usage instructions
-
+```ts
+import assert from "assert";
+import { kvsLocalStorage } from "@kvs/localstorage";
+(async () => {
+    type StorageSchema = {
+        a1: string;
+        b2: number;
+        c3: boolean;
+    };
+    const storage = await kvsLocalStorage<StorageSchema>({
+        name: "test",
+        version: 1
+    });
+    await storage.set("a1", "string");
+    await storage.set("b2", 42);
+    await storage.set("c3", false);
+    const a1 = await storage.get("a1");
+    const b2 = await storage.get("b2");
+    const c3 = await storage.get("c3");
+    assert.strictEqual(a1, "string");
+    assert.strictEqual(b2, 42);
+    assert.strictEqual(c3, false);
+})();
+```
 ## Changelog
 
 See [Releases page](https://github.com/azu/kvs/releases).

--- a/packages/localstorage/src/index.ts
+++ b/packages/localstorage/src/index.ts
@@ -1,13 +1,16 @@
-import { JsonValue, KvsStorage, kvsStorage, KVSStorageKey } from "@kvs/storage";
+import { JsonValue, KvsStorage, kvsStorage } from "@kvs/storage";
 import { KVS, KVSOptions } from "@kvs/types";
 
-export type KvsLocalStorage<K extends KVSStorageKey, V extends JsonValue> = KVS<K, V>;
-export type KvsLocalStorageOptions<K extends KVSStorageKey, V extends JsonValue> = KVSOptions<K, V> & {
+export type KvsLocalStorageSchema = {
+    [index: string]: JsonValue;
+};
+export type KvsLocalStorage<Schema extends KvsLocalStorageSchema> = KVS<Schema>;
+export type KvsLocalStorageOptions<Schema extends KvsLocalStorageSchema> = KVSOptions<Schema> & {
     kvsVersionKey?: string;
 };
-export const kvsLocalStorage = async <K extends KVSStorageKey, V extends JsonValue>(
-    options: KvsLocalStorageOptions<K, V>
-): Promise<KvsStorage<K, V>> => {
+export const kvsLocalStorage = async <Schema extends KvsLocalStorageSchema>(
+    options: KvsLocalStorageOptions<Schema>
+): Promise<KvsStorage<Schema>> => {
     return kvsStorage({
         ...options,
         storage: window.localStorage

--- a/packages/memorystorage/src/index.ts
+++ b/packages/memorystorage/src/index.ts
@@ -1,15 +1,18 @@
-import { JsonValue, KvsStorage, kvsStorage, KVSStorageKey } from "@kvs/storage";
+import { JsonValue, KvsStorage, kvsStorage } from "@kvs/storage";
 import { KVS, KVSOptions } from "@kvs/types";
 // @ts-ignore
 import localstorage from "localstorage-memory";
 
-export type KvsLocalStorage<K extends KVSStorageKey, V extends JsonValue> = KVS<K, V>;
-export type KvsLocalStorageOptions<K extends KVSStorageKey, V extends JsonValue> = KVSOptions<K, V> & {
+export type KvsMemoryStorageSchema = {
+    [index: string]: JsonValue;
+};
+export type KvsMemoryStorage<Schema extends KvsMemoryStorageSchema> = KVS<Schema>;
+export type KvsMemoryStorageOptions<Schema extends KvsMemoryStorageSchema> = KVSOptions<Schema> & {
     kvsVersionKey?: string;
 };
-export const kvsMemoryStorage = async <K extends KVSStorageKey, V extends JsonValue>(
-    options: KvsLocalStorageOptions<K, V>
-): Promise<KvsStorage<K, V>> => {
+export const kvsMemoryStorage = async <Schema extends KvsMemoryStorageSchema>(
+    options: KvsMemoryStorageOptions<Schema>
+): Promise<KvsStorage<Schema>> => {
     return kvsStorage({
         ...options,
         storage: localstorage

--- a/packages/node-localstorage/src/index.ts
+++ b/packages/node-localstorage/src/index.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { JsonValue, KvsStorage, kvsStorage, KVSStorageKey } from "@kvs/storage";
+import { JsonValue, KvsStorage, kvsStorage } from "@kvs/storage";
 import { KVS, KVSOptions } from "@kvs/types";
 // @ts-ignore
 import { LocalStorage } from "node-localstorage";
@@ -8,14 +8,17 @@ import appRoot from "app-root-path";
 // @ts-ignore
 import mkdirp from "mkdirp";
 
-export type KvsLocalStorage<K extends KVSStorageKey, V extends JsonValue> = KVS<K, V>;
-export type KvsLocalStorageOptions<K extends KVSStorageKey, V extends JsonValue> = KVSOptions<K, V> & {
+export type KvsLocalStorageSchema = {
+    [index: string]: JsonValue;
+};
+export type KvsLocalStorage<Schema extends KvsLocalStorageSchema> = KVS<Schema>;
+export type KvsLocalStorageOptions<Schema extends KvsLocalStorageSchema> = KVSOptions<Schema> & {
     kvsVersionKey?: string;
     storeFilePath?: string;
 };
-export const kvsLocalStorage = async <K extends KVSStorageKey, V extends JsonValue>(
-    options: KvsLocalStorageOptions<K, V>
-): Promise<KvsStorage<K, V>> => {
+export const kvsLocalStorage = async <Schema extends KvsLocalStorageSchema>(
+    options: KvsLocalStorageOptions<Schema>
+): Promise<KvsStorage<Schema>> => {
     const defaultCacheDir = path.join(appRoot.toString(), ".cache");
     if (!options.storeFilePath) {
         await mkdirp(defaultCacheDir);

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,6 +1,8 @@
 # @kvs/storage
 
-localstorage for KVS.
+Storage-like for KVS.
+
+You can inject Storage object like localStorage, sessionStorage to this storage.
 
 ## Install
 
@@ -10,7 +12,30 @@ Install with [npm](https://www.npmjs.com/):
 
 ## Usage
 
-- [ ] Write usage instructions
+```ts
+import { kvsStorage } from "@kvs/storage";
+(async () => {
+    type StorageSchema = {
+        a1: string;
+        b2: number;
+        c3: boolean;
+    };
+    const storage = await kvsStorage<StorageSchema>({
+        name: "test",
+        version: 1,
+        storage: localStorage
+    });
+    await storage.set("a1", "string");
+    await storage.set("b2", 42);
+    await storage.set("c3", false);
+    const a1 = await storage.get("a1");
+    const b2 = await storage.get("b2");
+    const c3 = await storage.get("c3");
+    assert.strictEqual(a1, "string");
+    assert.strictEqual(b2, 42);
+    assert.strictEqual(c3, false);
+})()
+```
 
 ## Changelog
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -13,6 +13,7 @@ Install with [npm](https://www.npmjs.com/):
 ## Usage
 
 ```ts
+import assert from "assert";
 import { kvsStorage } from "@kvs/storage";
 (async () => {
     type StorageSchema = {
@@ -34,7 +35,7 @@ import { kvsStorage } from "@kvs/storage";
     assert.strictEqual(a1, "string");
     assert.strictEqual(b2, 42);
     assert.strictEqual(c3, false);
-})()
+})();
 ```
 
 ## Changelog

--- a/packages/storage/test/index.test.ts
+++ b/packages/storage/test/index.test.ts
@@ -59,7 +59,7 @@ describe("@kvs/storage", () => {
         };
         const storage = await kvsStorage<StorageSchema>({
             name: databaseName,
-            version: 2,
+            version: 1,
             storage: localStorage
         });
         await storage.set("a1", "string");

--- a/packages/storage/test/index.test.ts
+++ b/packages/storage/test/index.test.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { kvsStorage } from "../src";
 import { createKVSTestCase } from "@kvs/common-test-case";
 
@@ -45,8 +46,30 @@ const deleteAllDB = async () => {
         console.error("deleteAllDB", error);
     }
 };
+
 describe("@kvs/storage", () => {
     before(deleteAllDB);
     afterEach(deleteAllDB);
     kvsTestCase.run();
+    it("example", async () => {
+        type StorageSchema = {
+            a1: string;
+            b2: number;
+            c3: boolean;
+        };
+        const storage = await kvsStorage<StorageSchema>({
+            name: databaseName,
+            version: 2,
+            storage: localStorage
+        });
+        await storage.set("a1", "string");
+        await storage.set("b2", 42);
+        await storage.set("c3", false);
+        const a1 = await storage.get("a1");
+        const b2 = await storage.get("b2");
+        const c3 = await storage.get("c3");
+        assert.strictEqual(a1, "string");
+        assert.strictEqual(b2, 42);
+        assert.strictEqual(c3, false);
+    });
 });


### PR DESCRIPTION

Useful interface.

- Add limitation to IndexedDB : key is string, value is JsonValue

```ts
import assert from "assert";
import { kvsStorage } from "@kvs/storage";
(async () => {
    type StorageSchema = {
        a1: string;
        b2: number;
        c3: boolean;
    };
    const storage = await kvsStorage<StorageSchema>({
        name: "test",
        version: 1,
        storage: localStorage
    });
    await storage.set("a1", "string");
    await storage.set("b2", 42);
    await storage.set("c3", false);
    const a1 = await storage.get("a1");
    const b2 = await storage.get("b2");
    const c3 = await storage.get("c3");
    assert.strictEqual(a1, "string");
    assert.strictEqual(b2, 42);
    assert.strictEqual(c3, false);
})();
```

fix #1 