### PR TITLE
Drop localstorage-memory dependency

### DIFF
--- a/packages/memorystorage/package.json
+++ b/packages/memorystorage/package.json
@@ -1,65 +1,63 @@
 {
-  "name": "@kvs/memorystorage",
-  "version": "1.0.0",
-  "description": "Node.js localstorage for KVS.",
-  "keywords": [
-    "kvs",
-    "browser",
-    "localstorage"
-  ],
-  "homepage": "https://github.com/azu/kvs/tree/master/packages/memorystorage/",
-  "bugs": {
-    "url": "https://github.com/azu/kvs/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/azu/kvs.git"
-  },
-  "license": "MIT",
-  "author": "azu",
-  "sideEffects": false,
-  "main": "lib/index.js",
-  "module": "module/index.js",
-  "types": "lib/index.d.ts",
-  "directories": {
-    "lib": "lib",
-    "test": "test"
-  },
-  "files": [
-    "bin/",
-    "lib/",
-    "module"
-  ],
-  "scripts": {
-    "build": "tsc -p . && tsc --project ./tsconfig.module.json",
-    "clean": "rimraf lib/ module/",
-    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
-    "prepublishOnly": "npm run clean && npm run build",
-    "test": "mocha \"test/**/*.ts\"",
-    "watch": "tsc -p . --watch"
-  },
-  "prettier": {
-    "printWidth": 120,
-    "singleQuote": false,
-    "tabWidth": 4,
-    "trailingComma": "none"
-  },
-  "dependencies": {
-    "localstorage-memory": "^1.0.3"
-  },
-  "devDependencies": {
-    "@jsdevtools/karma-config": "^3.1.7",
-    "@kvs/common-test-case": "^1.0.0",
-    "@types/mocha": "^8.0.1",
-    "@types/node": "^14.0.27",
-    "lerna": "^3.22.1",
-    "mocha": "^8.1.1",
-    "prettier": "^2.0.5",
-    "rimraf": "^3.0.2",
-    "ts-loader": "^8.0.2",
-    "typescript": "^3.9.7"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@kvs/memorystorage",
+    "version": "1.0.0",
+    "description": "Node.js localstorage for KVS.",
+    "keywords": [
+        "kvs",
+        "browser",
+        "localstorage"
+    ],
+    "homepage": "https://github.com/azu/kvs/tree/master/packages/memorystorage/",
+    "bugs": {
+        "url": "https://github.com/azu/kvs/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/azu/kvs.git"
+    },
+    "license": "MIT",
+    "author": "azu",
+    "sideEffects": false,
+    "main": "lib/index.js",
+    "module": "module/index.js",
+    "types": "lib/index.d.ts",
+    "directories": {
+        "lib": "lib",
+        "test": "test"
+    },
+    "files": [
+        "bin/",
+        "lib/",
+        "module"
+    ],
+    "scripts": {
+        "build": "tsc -p . && tsc --project ./tsconfig.module.json",
+        "clean": "rimraf lib/ module/",
+        "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+        "prepublishOnly": "npm run clean && npm run build",
+        "test": "mocha \"test/**/*.ts\"",
+        "watch": "tsc -p . --watch"
+    },
+    "prettier": {
+        "printWidth": 120,
+        "singleQuote": false,
+        "tabWidth": 4,
+        "trailingComma": "none"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "@jsdevtools/karma-config": "^3.1.7",
+        "@kvs/common-test-case": "^1.0.0",
+        "@types/mocha": "^8.0.1",
+        "@types/node": "^14.0.27",
+        "lerna": "^3.22.1",
+        "mocha": "^8.1.1",
+        "prettier": "^2.0.5",
+        "rimraf": "^3.0.2",
+        "ts-loader": "^8.0.2",
+        "typescript": "^3.9.7"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/memorystorage/src/index.ts
+++ b/packages/memorystorage/src/index.ts
@@ -1,7 +1,8 @@
 import { JsonValue, KvsStorage, kvsStorage } from "@kvs/storage";
 import { KVS, KVSOptions } from "@kvs/types";
 // @ts-ignore
-import localstorage from "localstorage-memory";
+// import localstorage from "localstorage-memory";
+import localstorage from "./localstorage-memory";
 
 export type KvsMemoryStorageSchema = {
     [index: string]: JsonValue;

--- a/packages/memorystorage/src/localstorage-memory.ts
+++ b/packages/memorystorage/src/localstorage-memory.ts
@@ -1,0 +1,35 @@
+// another implements by https://github.com/gr2m/localstorage-memory/blob/master/lib/localstorage-memory.js
+class LocalStorageMemory {
+    cache: { [k: string]: string } = {};
+    length = 0;
+    getItem(key: string) {
+        if (key in this.cache) {
+            return this.cache[key];
+        }
+        return null;
+    }
+    setItem(key: string, value: string) {
+        if (typeof value === "undefined") {
+            this.removeItem(key);
+        } else {
+            if (!this.cache.hasOwnProperty(key)) {
+                this.length++;
+            }
+            this.cache[key] = "" + value;
+        }
+    }
+    removeItem(key: string) {
+        if (this.cache.hasOwnProperty(key)) {
+            delete this.cache[key];
+            this.length--;
+        }
+    }
+    key(index: any) {
+        return Object.keys(this.cache)[index] || null;
+    }
+    clear() {
+        this.cache = {};
+        this.length = 0;
+    }
+}
+export default new LocalStorageMemory();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,11 +7836,6 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-localstorage-memory@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/localstorage-memory/-/localstorage-memory-1.0.3.tgz#566b37968fe0c4d76ba36a6da564fa613945ca72"
-  integrity sha512-t9P8WB6DcVttbw/W4PIE8HOqum8Qlvx5SjR6oInwR9Uia0EEmyUeBh7S+weKByW+l/f45Bj4L/dgZikGFDM6ng==
-
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"


### PR DESCRIPTION
To support rollup, I need to drop localstorage-memory.