### PR TITLE
fix(indexeddb): create store when initial version > 1

### DIFF
--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -36,7 +36,7 @@ const openDB = ({
             const database = openRequest.result;
             try {
                 // create table at first time
-                if (!newVersion || newVersion <= 1) {
+                if (!newVersion || newVersion <= 1 || oldVersion === 0) {
                     database.createObjectStore(tableName);
                 }
             } catch (e) {


### PR DESCRIPTION
Fixes #46

Issueで報告した初期バージョンに1より大きい値を指定した場合でも
テーブル(store)が生成されるように `oldVersion === 0` の判定を追加しました。
よろしくお願いいたします。